### PR TITLE
Add base classes in skmp/robot/robot.py to avoid repeated code modification in downstream programs due to changes from skmp API updates

### DIFF
--- a/skmp/robot/robot.py
+++ b/skmp/robot/robot.py
@@ -46,10 +46,10 @@ class Robot(RobotModelFromURDF):
             end_effector_list.rpys,
         ):
             setattr(self, end_effector_name, CascadedCoords(getattr(self, link_name), name=end_effector_name))
-            getattr(self, end_effector_name).translate(position)
             getattr(self, end_effector_name).rotate(rpy[0], "x")
             getattr(self, end_effector_name).rotate(rpy[1], "y")
             getattr(self, end_effector_name).rotate(rpy[2], "z")
+            getattr(self, end_effector_name).translate(position)
 
 
 class RobotSurrounding:
@@ -71,10 +71,10 @@ class RobotSurrounding:
             try:
                 shapeClass = getattr(module, shape)
                 setattr(self, name, shapeClass(size, with_sdf=True))
-                getattr(self, name).translate(position)
                 getattr(self, name).rotate(rpy[0], "x")
                 getattr(self, name).rotate(rpy[1], "y")
                 getattr(self, name).rotate(rpy[2], "z")
+                getattr(self, name).translate(position)
                 getattr(self, name).set_color(color)
                 self.sdf_list.append(getattr(self, name).sdf)
             except ImportError as e:

--- a/skmp/robot/robot.py
+++ b/skmp/robot/robot.py
@@ -112,7 +112,7 @@ class RobotConfig:
             try:
                 robot_model.add_new_link(end_effector_name, link_id, position, rpy)
             except Exception as e:
-                print(f"Error adding {end_effector_name}: {e}")
+                print(f"[Warning] Failed to add {end_effector_name}: {e}")
 
     def get_endeffector_kin(
             self,

--- a/skmp/robot/robot.py
+++ b/skmp/robot/robot.py
@@ -75,7 +75,7 @@ class RobotSurrounding:
                 getattr(self, name).rotate(rpy[0], "x")
                 getattr(self, name).rotate(rpy[1], "y")
                 getattr(self, name).rotate(rpy[2], "z")
-                getattr(self, name).visual_mesh.visual.face_colors = color
+                getattr(self, name).set_color(color)
                 self.sdf_list.append(getattr(self, name).sdf)
             except ImportError as e:
                 print(f"Error importing {shape}: {e}")

--- a/skmp/robot/robot.py
+++ b/skmp/robot/robot.py
@@ -1,0 +1,139 @@
+import importlib
+from typing import List
+from pathlib import Path
+from dataclasses import dataclass
+
+from skrobot.model import Link
+from skrobot.sdf import UnionSDF
+from skrobot.coordinates import CascadedCoords
+from skrobot.models.urdf import RobotModelFromURDF
+
+from skmp.constraint import BoxConst
+from skmp.kinematics import CollSphereKinematicsMap, EndEffectorKinematicsMap
+
+from tinyfk import BaseType, KinematicModel, RotationType
+
+
+@dataclass
+class EndEffectorList:
+    link_names: List[str]
+    end_effector_names: List[str]
+    positions: List[List[float]]
+    rpys: List[List[float]]
+
+
+@dataclass
+class SurroundingList:
+    name: List[str]
+    shape: List[str]
+    size: List[List[float]]
+    position: List[List[float]]
+    rpy: List[List[float]]
+    color: List[List[int]]
+
+
+class Robot(RobotModelFromURDF):
+    urdf_path: Path
+    end_effector_list: EndEffectorList
+
+    def __init__(self, urdf_path: str, end_effector_list: EndEffectorList):
+        super().__init__(urdf_file=urdf_path)
+
+        for link_name, end_effector_name, position, rpy in zip(
+            end_effector_list.link_names,
+            end_effector_list.end_effector_names,
+            end_effector_list.positions,
+            end_effector_list.rpys,
+        ):
+            setattr(self, end_effector_name, CascadedCoords(getattr(self, link_name), name=end_effector_name))
+            getattr(self, end_effector_name).translate(position)
+            getattr(self, end_effector_name).rotate(rpy[0], "x")
+            getattr(self, end_effector_name).rotate(rpy[1], "y")
+            getattr(self, end_effector_name).rotate(rpy[2], "z")
+
+
+class RobotSurrounding:
+    surrounding_list: SurroundingList
+
+    def __init__(self, surrounding_list: SurroundingList):
+        package_name = "skrobot.model.primitives"
+        module = importlib.import_module(package_name)
+        self.sdf_list = []
+        self.surrounding_list = surrounding_list
+        for name, shape, size, position, rpy, color in zip(
+            surrounding_list.name,
+            surrounding_list.shape,
+            surrounding_list.size,
+            surrounding_list.position,
+            surrounding_list.rpy,
+            surrounding_list.color,
+        ):
+            try:
+                shapeClass = getattr(module, shape)
+                setattr(self, name, shapeClass(size, with_sdf=True))
+                getattr(self, name).translate(position)
+                getattr(self, name).rotate(rpy[0], "x")
+                getattr(self, name).rotate(rpy[1], "y")
+                getattr(self, name).rotate(rpy[2], "z")
+                getattr(self, name).visual_mesh.visual.face_colors = color
+                self.sdf_list.append(getattr(self, name).sdf)
+            except ImportError as e:
+                print(f"Error importing {shape}: {e}")
+            except AttributeError as e:
+                print(f"{shape} does not exist in {package_name}.")
+
+    def append_sdf(self, objects: List[Link]):
+        self.sdf_list.extend([obj.sdf for obj in objects])
+
+    def get_sdf_list(self):
+        sdf = UnionSDF(self.sdf_list)
+        return sdf
+
+    def get_object_list(self):
+        return [getattr(self, name) for name in self.surrounding_list.name]
+
+
+class RobotConfig:
+    urdf_path: Path
+    end_effector_list: EndEffectorList
+
+    def __init__(self, urdf_path: str, end_effector_list: EndEffectorList):
+        self.urdf_path = Path(urdf_path).expanduser()
+        self.end_effector_list = end_effector_list
+
+    def add_end_coords(self, robot_model: KinematicModel) -> None:
+        for link_name, end_effector_name, position, rpy in zip(
+            self.end_effector_list.link_names,
+            self.end_effector_list.end_effector_names,
+            self.end_effector_list.positions,
+            self.end_effector_list.rpys,
+        ):
+            link_id = robot_model.get_link_ids([link_name])[0]
+            try:
+                robot_model.add_new_link(end_effector_name, link_id, position, rpy)
+            except Exception as e:
+                print(f"Error adding {end_effector_name}: {e}")
+
+    def get_endeffector_kin(
+            self,
+            base_type: BaseType = BaseType.FIXED,
+            rot_type: RotationType = RotationType.XYZW
+    ) -> EndEffectorKinematicsMap:
+        kinmap = EndEffectorKinematicsMap(
+            self.urdf_path,
+            self.get_control_joint_names(),
+            end_effector_names=self.end_effector_list.end_effector_names,
+            base_type=base_type,
+            rot_type=rot_type,
+            fksolver_init_hook=self.add_end_coords,
+        )
+        return kinmap
+
+    def get_box_const(self) -> BoxConst:
+        raise NotImplementedError
+
+    def get_control_joint_names(self) -> List[str]:
+        raise NotImplementedError
+
+    def get_collision_kin(self) -> CollSphereKinematicsMap:
+        raise NotImplementedError


### PR DESCRIPTION
## Add base classes in skmp/robot/robot.py

- [x] Updated and verified on a0b and fetch demo codes with the newly introduced robot.py
- [ ] pr2 and jaxon demo codes are left without modification

### Changes

- Define all surrounding objects using SurroundingList Class
```
    surrounding_list = SurroundingList(
        name=["pole", "table", "obstacle"],
        shape=["Box", "Box", "Box"],
        size=[[0.2, 0.2, 1.5], [2.0, 2.0, 0.1], [0.05, 0.05, 0.4]],
        position=[[-0.2, 0, -0.75], [0.0, 0.0, -0.5], [0.5, 0.15, -0.3]],
        rpy=[[0, 0, 0], [0, 0, 0], [0, 0, 0]],
        color=[[120, 120, 120, 120], [120, 120, 0, 120], [120, 0, 0, 120]],
    )
    surrounding = RobotSurrounding(surrounding_list)
    # Get list containing sdf of all the added objects
    sdf = surrounding.get_sdf_list()

    # To append extra sdf
    self_body_obstacles = conf.get_self_body_obstacles()
    surrounding.append_sdf(self_body_obstacles)
```

- Define all end-effectors regarding to the desired robot urdf link using EndEffectorList Class
```
    end_effector_list = EndEffectorList(
        link_names=["RARM_LINK5"],
        end_effector_names=["rarm_end_coords"],
        positions=[[0.25, 0, 0.0]],
        rpys=[[0, 0, 0]],
    )
    with mesh_simplify_factor(0.3):
        model = Robot(urdf_path, end_effector_list)
```

- Using EndEffectorList instance to initialize each robot Config Class
```
class A0BConfig(RobotConfig):
    def __init__(self, urdf_path: str, end_effector_list: EndEffectorList):
        super().__init__(urdf_path, end_effector_list)
```
- For config class of the robot inheriting from RobotConfig() Class, the only three methods that must to be implemented are:
    - get_box_const()
    - get_control_joint_names()
    - get_collision_kin()

